### PR TITLE
add pylint

### DIFF
--- a/.config/nvim/lua/plugins/README.md
+++ b/.config/nvim/lua/plugins/README.md
@@ -1,0 +1,46 @@
+
+## Using Pylint with NeoVim via nvim-starter-kit
+
+1.  install system packages
+
+```
+    apt install python3.10-venv
+    apt install python3-pylsp
+```
+
+Note: if these are not available as system packages it may be possible to install these via `pip`
+
+2.  install Python packages
+
+```
+    pip install "python-lsp-server[all]"
+    pip install pylint==3.0.3
+```
+
+3.  start nvim and install packages
+
+Start nvim and get LspConfig to install pylsp:
+
+```
+    :LspConfig
+    x) pylsp
+```
+
+References:
+
+[Pylsp setup for Neovim in 2023](https://jdhao.github.io/2023/07/22/neovim-pylsp-setup/) How to add pylint to Neovim
+
+[How to Setup Nvim LSP for Code Analysis, Autocompletion and Linting](https://miikanissi.com/blog/how-to-setup-nvim-lsp-for-code-analysis-autocompletion-and-linting/)
+
+[Python LSP Server](https://github.com/python-lsp/python-lsp-server)
+
+[nvim lspconfig](https://github.com/neovim/nvim-lspconfig)
+
+[General python LSP/completion advice](https://www.reddit.com/r/neovim/comments/137u0z8/general_python_lspcompletion_advice/) some comments about pyright vs. pylsp
+
+[Python Lsp Setup](https://waylonwalker.com/setup-pylsp/) lsp setup example
+
+[nvim-lspconfig w/pylsp](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#pylsp) specific nvim-lspconfig for pylsp
+
+[Trying to Configure pyls through nvim-lspconfig](https://stackoverflow.com/questions/69405029/trying-to-configure-pyls-through-nvim-lspconfig) some SO q&a
+

--- a/.config/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/.config/nvim/lua/plugins/nvim-lspconfig.lua
@@ -77,7 +77,7 @@ return {
       pylsp = {
         plugins = {
           -- formatter options
-          --wt: black = { enabled = true },
+          --no thanks: black = { enabled = true },
           autopep8 = { enabled = false },
           yapf = { enabled = false },
           -- linter options

--- a/.config/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/.config/nvim/lua/plugins/nvim-lspconfig.lua
@@ -67,6 +67,39 @@ return {
         },
       },
     }
+
+  -- ++++++++++++++++++
+  -- mostly from:  https://jdhao.github.io/2023/07/22/neovim-pylsp-setup/
+
+  lspconfig.pylsp.setup {
+    on_attach = custom_attach,
+    settings = {
+      pylsp = {
+        plugins = {
+          -- formatter options
+          --wt: black = { enabled = true },
+          autopep8 = { enabled = false },
+          yapf = { enabled = false },
+          -- linter options
+          pylint = { enabled = true, executable = "pylint" },
+          pyflakes = { enabled = false },
+          pycodestyle = { enabled = false },
+          -- type checker
+          pylsp_mypy = { enabled = true },
+          -- auto-completion options
+          jedi_completion = { fuzzy = true },
+          -- import sorting
+          pyls_isort = { enabled = true },
+        },
+      },
+    },
+    flags = {
+        debounce_text_changes = 200,
+    },
+    capabilities = capabilities,
+  }
+  -- ++++++++++++++++++
+
   end
 }
 

--- a/.config/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/.config/nvim/lua/plugins/nvim-lspconfig.lua
@@ -68,37 +68,37 @@ return {
       },
     }
 
-  -- ++++++++++++++++++
-  -- mostly from:  https://jdhao.github.io/2023/07/22/neovim-pylsp-setup/
+    -- ++++++++++++++++++
+    -- mostly from:  https://jdhao.github.io/2023/07/22/neovim-pylsp-setup/
 
-  lspconfig.pylsp.setup {
-    on_attach = custom_attach,
-    settings = {
-      pylsp = {
-        plugins = {
-          -- formatter options
-          --no thanks: black = { enabled = true },
-          autopep8 = { enabled = false },
-          yapf = { enabled = false },
-          -- linter options
-          pylint = { enabled = true, executable = "pylint" },
-          pyflakes = { enabled = false },
-          pycodestyle = { enabled = false },
-          -- type checker
-          pylsp_mypy = { enabled = true },
-          -- auto-completion options
-          jedi_completion = { fuzzy = true },
-          -- import sorting
-          pyls_isort = { enabled = true },
+    -- pylint settings
+    lspconfig.pylsp.setup {
+      on_attach = lsp_attach,
+      settings = {
+        pylsp = {
+          plugins = {
+            -- formatter options
+            --no thanks: black = { enabled = true },
+            autopep8 = { enabled = false },
+            yapf = { enabled = false },
+            -- linter options
+            pylint = { enabled = true, executable = "pylint" },
+            pyflakes = { enabled = false },
+            pycodestyle = { enabled = false },
+            -- type checker
+            pylsp_mypy = { enabled = true },
+            -- auto-completion options
+            jedi_completion = { fuzzy = true },
+            -- import sorting
+            pyls_isort = { enabled = true },
+          },
         },
       },
-    },
-    flags = {
-        debounce_text_changes = 200,
-    },
-    capabilities = capabilities,
-  }
-  -- ++++++++++++++++++
+      flags = {
+          debounce_text_changes = 200,
+      },
+      capabilities = lsp_capabilities,
+    }
 
   end
 }


### PR DESCRIPTION
Hello,
Thank you very much for the starter kit!  I was finally able to run `nvim` with `pylint` and without `pyright`.  (I found pyright very difficult to work with and configure, and it was extremely verbose).

I was able to get nvim to use (only) pylint thanks to your starter kit and with some help from [jdhao](https://jdhao.github.io/2023/07/22/neovim-pylsp-setup/)

Would you be interested in including this in your starter kit?

I'm not sure if the section of `nvim-lspconfig.lua` could be made into its own file; I'm not familiar with Lua configs.  But at least this works for me.

Thanks again.